### PR TITLE
Incorporate C++11 libraries into the stanford libraries

### DIFF
--- a/StanfordCPPLib/simpio.cpp
+++ b/StanfordCPPLib/simpio.cpp
@@ -35,7 +35,7 @@ static void appendSpace(std::string& prompt);
  */
 
 int getInteger(const std::string& prompt,
-        const std::string& reprompt) {
+               const std::string& reprompt) {
     std::string promptCopy = prompt;
     appendSpace(promptCopy);
     int value;
@@ -76,7 +76,7 @@ std::string getLine(const std::string& prompt) {
 }
 
 void getLine(const std::string& prompt,
-        std::string& out) {
+             std::string& out) {
     std::string promptCopy = prompt;
     appendSpace(promptCopy);
     std::cout << promptCopy;
@@ -84,12 +84,12 @@ void getLine(const std::string& prompt,
 }
 
 void getLine(std::istream& input,
-        std::string& out) {
+             std::string& out) {
     getline(input, out);
 }
 
 double getReal(const std::string& prompt,
-        const std::string& reprompt) {
+               const std::string& reprompt) {
     std::string promptCopy = prompt;
     appendSpace(promptCopy);
     double value;
@@ -115,8 +115,8 @@ double getReal(const std::string& prompt,
 }
 
 bool getYesOrNo(const std::string& prompt,
-        const std::string& reprompt,
-        const std::string& defaultValue) {
+                const std::string& reprompt,
+                const std::string& defaultValue) {
     std::string promptCopy = prompt;
     appendSpace(promptCopy);
     bool value;

--- a/StanfordCPPLib/simpio.cpp
+++ b/StanfordCPPLib/simpio.cpp
@@ -35,7 +35,7 @@ static void appendSpace(std::string& prompt);
  */
 
 int getInteger(const std::string& prompt,
-               const std::string& reprompt) {
+        const std::string& reprompt) {
     std::string promptCopy = prompt;
     appendSpace(promptCopy);
     int value;
@@ -44,9 +44,13 @@ int getInteger(const std::string& prompt,
         std::string line;
         getline(std::cin, line);
         std::istringstream stream(line);
-        stream >> value >> std::ws;
-        if (!stream.fail() && stream.eof()) {
-            break;
+        char junk;
+        stream >> value;
+        if (!stream.fail()) {
+            stream >> junk;
+            if (stream.fail()) {
+                break;
+            }
         }
         std::cout << (reprompt.empty() ? GETINTEGER_DEFAULT_REPROMPT : reprompt) << std::endl;
         if (promptCopy.empty()) {
@@ -72,7 +76,7 @@ std::string getLine(const std::string& prompt) {
 }
 
 void getLine(const std::string& prompt,
-             std::string& out) {
+        std::string& out) {
     std::string promptCopy = prompt;
     appendSpace(promptCopy);
     std::cout << promptCopy;
@@ -80,12 +84,12 @@ void getLine(const std::string& prompt,
 }
 
 void getLine(std::istream& input,
-             std::string& out) {
+        std::string& out) {
     getline(input, out);
 }
 
 double getReal(const std::string& prompt,
-               const std::string& reprompt) {
+        const std::string& reprompt) {
     std::string promptCopy = prompt;
     appendSpace(promptCopy);
     double value;
@@ -94,9 +98,13 @@ double getReal(const std::string& prompt,
         std::string line;
         getline(std::cin, line);
         std::istringstream stream(line);
-        stream >> value >> std::ws;
-        if (!stream.fail() && stream.eof()) {
-            break;
+        char junk;
+        stream >> value;
+        if (!stream.fail()) {
+            stream >> junk;
+            if (stream.fail()) {
+                break;
+            }
         }
         std::cout << (reprompt.empty() ? GETREAL_DEFAULT_REPROMPT : reprompt) << std::endl;
         if (promptCopy.empty()) {
@@ -107,8 +115,8 @@ double getReal(const std::string& prompt,
 }
 
 bool getYesOrNo(const std::string& prompt,
-                const std::string& reprompt,
-                const std::string& defaultValue) {
+        const std::string& reprompt,
+        const std::string& defaultValue) {
     std::string promptCopy = prompt;
     appendSpace(promptCopy);
     bool value;

--- a/StanfordCPPLib_QtCreatorProject/stanfordcpplib.pro
+++ b/StanfordCPPLib_QtCreatorProject/stanfordcpplib.pro
@@ -77,7 +77,7 @@ exists($$PWD/*.h) {
 # set up flags for the C++ compiler
 # (In general, many warnings/errors are enabled to tighten compile-time checking.
 # A few overly pedantic/confusing errors are turned off for simplicity.)
-QMAKE_CXXFLAGS += -std=c++11
+CONFIG += c++11
 QMAKE_CXXFLAGS += -Wall
 QMAKE_CXXFLAGS += -Wextra
 QMAKE_CXXFLAGS += -Wreturn-type


### PR DESCRIPTION
The change in the .pro file allows mac users to use c++11 library features (both new libraries like unordered_map and additions to old libraries like .pop_front for string). Unfortunately, the most recent C++ library version for mac has a bug that apple hasn't fixed yet (it's only been 2 years... they'll get to it eventually) that causes the ws stream manipulator to misbehave so I removed that from simpio.cpp
