### PR TITLE
Bug fix: print cost of vertex once

### DIFF
--- a/StanfordCPPLib/basicgraph.cpp
+++ b/StanfordCPPLib/basicgraph.cpp
@@ -95,9 +95,6 @@ Vertex& Vertex::operator =(Vertex&& other) {
 
 std::ostream& operator <<(std::ostream& out, const Vertex& v) {
     out << "Vertex{name=" << v.name;
-    if (v.cost != 0.0) {
-        out << ", cost=" << v.cost;
-    }
     out << ", cost=" << v.cost;
     out << ", visited=" << (v.visited ? "true" : "false");
     out << ", previous=" << (v.previous == NULL ? std::string("NULL") : v.previous->name);


### PR DESCRIPTION
As specified in header for basicgraph.h we ouput the cost of the of the vertex in the output stream just once