### PR TITLE
Bug fix: print cost of vertex once

### DIFF
--- a/StanfordCPPLib/basicgraph.cpp
+++ b/StanfordCPPLib/basicgraph.cpp
@@ -95,9 +95,6 @@ Vertex& Vertex::operator =(Vertex&& other) {
 
 std::ostream& operator <<(std::ostream& out, const Vertex& v) {
     out << "Vertex{name=" << v.name;
-    if (v.cost != 0.0) {
-        out << ", cost=" << v.cost;
-    }
     out << ", cost=" << v.cost;
     out << ", visited=" << (v.visited ? "true" : "false");
     out << ", previous=" << (v.previous == NULL ? std::string("NULL") : v.previous->name);

--- a/StanfordCPPLib/basicgraph.cpp
+++ b/StanfordCPPLib/basicgraph.cpp
@@ -95,7 +95,9 @@ Vertex& Vertex::operator =(Vertex&& other) {
 
 std::ostream& operator <<(std::ostream& out, const Vertex& v) {
     out << "Vertex{name=" << v.name;
-    out << ", cost=" << v.cost;
+    if (v.cost != 0.0) {
+        out << ", cost=" << v.cost;
+    }
     out << ", visited=" << (v.visited ? "true" : "false");
     out << ", previous=" << (v.previous == NULL ? std::string("NULL") : v.previous->name);
 


### PR DESCRIPTION
Fix: In the basic graph we print to the output stream the cost only when is different than 0
