### PR TITLE
filelib bugfixes

### DIFF
--- a/StanfordCPPLib/io/filelib.cpp
+++ b/StanfordCPPLib/io/filelib.cpp
@@ -44,16 +44,21 @@ static bool recursiveMatch(const std::string& str, int sx, const std::string& pa
 /* Implementations */
 
 void createDirectory(const std::string& path) {
-    return stanfordcpplib::getPlatform()->filelib_createDirectory(path);
+    return stanfordcpplib::getPlatform()->filelib_createDirectory(expandPathname(path));
 }
 
 void createDirectoryPath(const std::string& path) {
-    size_t cp = 1;
+    size_t cp = 0;
     if (path == "") return;
-    while ((cp = path.find('/', cp + 1)) != std::string::npos) {
-        createDirectory(path.substr(0, cp - 1));
+    std::string expandedPath = expandPathname(path);
+    char sep = getDirectoryPathSeparator()[0];
+    if (expandedPath.substr(1, 2) == ":\\") { // Windows drive letter followed by ':\'
+        cp = 2;
     }
-    createDirectory(path);
+    while ((cp = expandedPath.find(sep, cp + 1)) != std::string::npos) {
+       createDirectory(expandedPath.substr(0, cp));
+    }
+    createDirectory(expandedPath);
 }
 
 std::string defaultExtension(const std::string& filename, const std::string& ext) {
@@ -79,7 +84,7 @@ std::string defaultExtension(const std::string& filename, const std::string& ext
 }
 
 void deleteFile(const std::string& filename) {
-    remove(expandPathname(filename).c_str());
+    stanfordcpplib::getPlatform()->filelib_deleteFile(expandPathname(filename));
 }
 
 std::string expandPathname(const std::string& filename) {
@@ -185,11 +190,11 @@ std::string getTempDirectory() {
 }
 
 bool isDirectory(const std::string& filename) {
-    return stanfordcpplib::getPlatform()->filelib_isDirectory(filename);
+    return stanfordcpplib::getPlatform()->filelib_isDirectory(expandPathname(filename));
 }
 
 bool isFile(const std::string& filename) {
-    return stanfordcpplib::getPlatform()->filelib_isFile(filename);
+    return stanfordcpplib::getPlatform()->filelib_isFile(expandPathname(filename));
 }
 
 bool isSymbolicLink(const std::string& filename) {
@@ -206,7 +211,7 @@ void listDirectory(const std::string& path, Vector<std::string>& list) {
 }
 
 void listDirectory(const std::string& path, std::vector<std::string>& list) {
-    return stanfordcpplib::getPlatform()->filelib_listDirectory(path, list);
+    return stanfordcpplib::getPlatform()->filelib_listDirectory(expandPathname(path), list);
 }
 
 Vector<std::string> listDirectory(const std::string& path) {

--- a/StanfordCPPLib/private/platform.cpp
+++ b/StanfordCPPLib/private/platform.cpp
@@ -86,6 +86,7 @@
 
 #include "platform.h"
 #ifdef _WIN32
+#  include <direct.h>
 #  include <windows.h>
 #  include <tchar.h>
 #  undef MOUSE_EVENT
@@ -258,7 +259,7 @@ bool Platform::filelib_isFile(const std::string& filename) {
 // Unix implementation; see Windows implementation elsewhere in this file
 bool Platform::filelib_isSymbolicLink(const std::string& filename) {
     struct stat fileInfo;
-    if (stat(filename.c_str(), &fileInfo) != 0) {
+    if (lstat(filename.c_str(), &fileInfo) != 0) {
         return false;
     }
     return S_ISLNK(fileInfo.st_mode) != 0;
@@ -275,7 +276,7 @@ bool Platform::filelib_isDirectory(const std::string& filename) {
 
 // Unix implementation; see Windows implementation elsewhere in this file
 void Platform::filelib_setCurrentDirectory(const std::string& path) {
-    if (chdir(path.c_str()) == 0) {
+    if (chdir(path.c_str()) != 0) {
         std::string msg = "setCurrentDirectory: ";
         std::string err = std::string(strerror(errno));
         error(msg + err);
@@ -323,6 +324,11 @@ void Platform::filelib_createDirectory(const std::string& path) {
         std::string err = std::string(strerror(errno));
         error(msg + err);
     }
+}
+
+// Unix implementation; see Windows implementation elsewhere in this file
+void Platform::filelib_deleteFile(const std::string& path) {
+    remove(path.c_str());
 }
 
 // Unix implementation; see Windows implementation elsewhere in this file
@@ -443,8 +449,24 @@ std::string Platform::filelib_getTempDirectory() {
 
 // Windows implementation; see Unix implementation elsewhere in this file
 void Platform::filelib_createDirectory(const std::string& path) {
-    if (!CreateDirectoryA(path.c_str(), nullptr)) {
+    std::string pathStr = path;
+    if (endsWith(path, "\\")) {
+        pathStr = path.substr(0, path.length() - 1);
+    }
+    if (CreateDirectoryA(path.c_str(), nullptr) == 0) {
+        if (GetLastError() == ERROR_ALREADY_EXISTS && filelib_isDirectory(pathStr)) {
+            return;
+        }
         error("createDirectory: Can't create " + path);
+    }
+}
+
+// Windows implementation; see Unix implementation elsewhere in this file
+void Platform::filelib_deleteFile(const std::string& path) {
+    if(filelib_isDirectory(path)) {
+        RemoveDirectoryA(path.c_str());
+    } else {
+        DeleteFileA(path.c_str());
     }
 }
 

--- a/StanfordCPPLib/private/platform.h
+++ b/StanfordCPPLib/private/platform.h
@@ -98,6 +98,7 @@ public:
 
     std::string file_openFileDialog(const std::string& title, const std::string& mode, const std::string& path);
     void filelib_createDirectory(const std::string& path);
+    void filelib_deleteFile(const std::string& path);
     std::string filelib_expandPathname(const std::string& filename);
     bool filelib_fileExists(const std::string& filename);
     std::string filelib_getCurrentDirectory();


### PR DESCRIPTION
This patch addresses some small bugs in utility functions related to the handling of files, directories, and symbolic links. 

Relevant unit tests (expanded and updated versions of Eric Roberts' tests) can be found  [here](https://github.com/jlutgen/stanford-cpp-library-tests/tree/master/src) (in tests-JL-roberts/testFilelibLibrary.cpp).

Summary of changes:

- filelib.cpp
  - Use expandPathname in many functions so that pathnames like
    "~/x/y/z" work on Mac and Linux.
  - createDirectoryPath
    - Fix off-by-one errors in use of path.find() and path.substr().
    - Use expandPathname so createDirectory("~/x/y/z") works on Mac and Linux.
    - Fix so createDirectory("C:/x/y/z") works on Windows
          (was giving "Could not create directory: C:" error).
  - deleteFile
    - Call new platform-specific routines in platform.cpp. Was calling
          remove() from stdio.h, but remove() doesn't work correctly on 
          Windows (MinGW): POSIX standard says remove() should remove an empty 
          directory (by calling rmdir), but the version of remove() in the Windows C runtime 
          (msvcrt.dll) used by MinGW is broken and does not remove directories.
- platform.cpp
  - filelib_isSymbolicLink (mac/linux)
    - Use lstat instead of stat, because stat follows links and gives
          info on the target, not the link itself, so this function never
          returned 'true'.   
  - filelib_setCurrentDirectory
    - Fix bug where return value of 0 from chdir was treated as an error
          (chdir returns 0 on success).        
  - filelib_createDirectory (Windows)
    - Fix bug in Windows version that was causing createDirectoryPath
          to fail if part of the path already exists.
          For example, createDirectoryPath("a/b/c") was failing if "a/b"
          already existed.         
  - filelib_deleteFile
    - Added this function for both platforms (see deleteFile above)
   
          
            
    
        