### PR TITLE
Allow negative coordinates for graphics objects.

### DIFF
--- a/StanfordCPPLib/private/platform.cpp
+++ b/StanfordCPPLib/private/platform.cpp
@@ -1293,14 +1293,10 @@ void Platform::gobject_setAntialiasing(bool value) {
 void Platform::garc_setFrameRectangle(GObject* gobj, double x, double y,
                                       double width, double height) {
     std::ostringstream os;
-    if (x >= 0 && y >= 0 && width >= 0 && height >= 0) {
-        os << "GArc.setFrameRectangle(\"" << gobj << "\", "
-           << x << ", " << y << ", "
-           << width << ", " << height << ")";
-        putPipe(os.str());
-    } else {
-        error("GArc::setFrameRectangle: x, y, w, h must all be non-negative");
-    }
+    os << "GArc.setFrameRectangle(\"" << gobj << "\", "
+       << x << ", " << y << ", "
+       << width << ", " << height << ")";
+    putPipe(os.str());
 }
 
 void Platform::gwindow_draw(const GWindow& gw, const GObject* gobj) {
@@ -1376,22 +1372,14 @@ void Platform::gline_constructor(GObject* gobj, double x1, double y1,
 
 void Platform::gline_setStartPoint(GObject* gobj, double x, double y) {
     std::ostringstream os;
-    if (x >= 0 && y >= 0) {
-        os << "GLine.setStartPoint(\"" << gobj << "\", " << x << ", " << y << ")";
-        putPipe(os.str());
-    } else {
-        error("GLine::setStartPoint: x and y must both be non-negative");
-    }
+    os << "GLine.setStartPoint(\"" << gobj << "\", " << x << ", " << y << ")";
+    putPipe(os.str());
 }
 
 void Platform::gline_setEndPoint(GObject* gobj, double x, double y) {
     std::ostringstream os;
-    if (x >= 0 && y >= 0) {
-        os << "GLine.setEndPoint(\"" << gobj << "\", " << x << ", " << y << ")";
-        putPipe(os.str());
-    } else {
-        error("GLine::setEndPoint: x and y must both be non-negative");
-    }
+    os << "GLine.setEndPoint(\"" << gobj << "\", " << x << ", " << y << ")";
+    putPipe(os.str());
 }
 
 void Platform::garc_constructor(GObject* gobj, double width, double height,
@@ -1527,12 +1515,8 @@ void Platform::gpolygon_constructor(GObject* gobj) {
 
 void Platform::gpolygon_addVertex(GObject* gobj, double x, double y) {
     std::ostringstream os;
-    if (x >= 0 && y >= 0) {
-        os << "GPolygon.addVertex(\"" << gobj << "\", " << x << ", " << y << ")";
-        putPipe(os.str());
-    } else {
-        error("GPolygon::addVertex: x and y must both be non-negative");
-    }
+    os << "GPolygon.addVertex(\"" << gobj << "\", " << x << ", " << y << ")";
+    putPipe(os.str());
 }
 
 void Platform::goval_constructor(GObject* gobj, double width, double height) {


### PR DESCRIPTION
Graphics objects can have negative coordinates in the Java Back End. This update removes error-checks on the C++ side that would trigger an error() on negative coordinates.