### PR TITLE
Bugfix/negative hashcodes

### DIFF
--- a/StanfordCPPLib/collections/hashcode.h
+++ b/StanfordCPPLib/collections/hashcode.h
@@ -31,6 +31,7 @@ int hashCode(bool key);
 int hashCode(char key);
 int hashCode(double key);
 int hashCode(float key);
+int hashCode(long double key);
 int hashCode(int key);
 int hashCode(unsigned int key);
 int hashCode(long key);
@@ -147,3 +148,4 @@ int hashCode6(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) {
 #include "private/init.h"   // ensure that Stanford C++ lib is initialized
 
 #endif // _hashcode_h
+


### PR DESCRIPTION
The current implementation of hashCode(char) (and, similarly, hashCode(short)) can return negative values if char is signed. These changes have all of the overloads for hashCode call into hashCode(int), which strips off the sign bit, preventing any hash function from returning a negative value.

There are a few other changes in here:

1. Code paths for hashing strings, floats, and doubles now go through a unified implementation of a hash function. This is potentially a slowdown for hashCode(const char *) because of a call to strlen followed by the hashing. It does, however, make the other functions much easier to read.

2. Added in an overload hashCode(long double), which was missing.