### PR TITLE
Replace hashCodeN functions with a variadic hashCode() overload.

### DIFF
--- a/StanfordCPPLib/collections/gridlocation.cpp
+++ b/StanfordCPPLib/collections/gridlocation.cpp
@@ -29,7 +29,7 @@ std::string GridLocation::toString() const {
 }
 
 int hashCode(const GridLocation& loc) {
-    return hashCode2(loc.row, loc.col);
+    return hashCode(loc.row, loc.col);
 }
 
 bool operator <(const GridLocation& loc1, const GridLocation& loc2) {

--- a/StanfordCPPLib/collections/hashcode.h
+++ b/StanfordCPPLib/collections/hashcode.h
@@ -18,6 +18,7 @@
 #define _hashcode_h
 
 #include <string>
+#include <utility>
 
 /*
  * Function: hashCode
@@ -51,98 +52,24 @@ int hashMultiplier();   // Multiplier for each cycle
 int hashMask();         // All 1 bits except the sign
 
 /*
- * Computes a composite hash code from two values.
+ * Computes a composite hash code from a list of multiple values.
  * The components are scaled up so as to spread out the range of values
  * and reduce collisions.
  * The type of each value passed must have a suitable hashCode() function.
  */
-template <typename T1, typename T2>
-int hashCode2(T1 t1, T2 t2) {
-    int code = hashSeed();
-    code += hashCode(t1);
-    code *= hashMultiplier();
-    code += hashCode(t2);
-    return int(code & hashMask());
-}
+template <typename T1, typename T2, typename... Others>
+int hashCode(T1&& first, T2&& second, Others&&... remaining) {
+    int result = hashSeed();
 
-/*
- * Computes a composite hash code from three values.
- * The components are scaled up so as to spread out the range of values
- * and reduce collisions.
- * The type of each value passed must have a suitable hashCode() function.
- */
-template <typename T1, typename T2, typename T3>
-int hashCode3(T1 t1, T2 t2, T3 t3) {
-    int code = hashSeed();
-    code += hashCode(t1);
-    code *= hashMultiplier();
-    code += hashCode(t2);
-    code *= hashMultiplier();
-    code += hashCode(t3);
-    return int(code & hashMask());
-}
+    /* Compute the hash code for the last n - 1 arguments. */
+    result += hashCode(std::forward<T2>(second), std::forward<Others>(remaining)...);
 
-/*
- * Computes a composite hash code from four values.
- * The components are scaled up so as to spread out the range of values
- * and reduce collisions.
- * The type of each value passed must have a suitable hashCode() function.
- */
-template <typename T1, typename T2, typename T3, typename T4>
-int hashCode4(T1 t1, T2 t2, T3 t3, T4 t4) {
-    int code = hashSeed();
-    code += hashCode(t1);
-    code *= hashMultiplier();
-    code += hashCode(t2);
-    code *= hashMultiplier();
-    code += hashCode(t3);
-    code *= hashMultiplier();
-    code += hashCode(t4);
-    return int(code & hashMask());
-}
+    /* Update the hash to factor in the hash of the first element. */
+    result *= hashMultiplier();
+    result += hashCode(std::forward<T1>(first));
 
-/*
- * Computes a composite hash code from five values.
- * The components are scaled up so as to spread out the range of values
- * and reduce collisions.
- * The type of each value passed must have a suitable hashCode() function.
- */
-template <typename T1, typename T2, typename T3, typename T4, typename T5>
-int hashCode5(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) {
-    int code = hashSeed();
-    code += hashCode(t1);
-    code *= hashMultiplier();
-    code += hashCode(t2);
-    code *= hashMultiplier();
-    code += hashCode(t3);
-    code *= hashMultiplier();
-    code += hashCode(t4);
-    code *= hashMultiplier();
-    code += hashCode(t5);
-    return int(code & hashMask());
-}
-
-/*
- * Computes a composite hash code from six values.
- * The components are scaled up so as to spread out the range of values
- * and reduce collisions.
- * The type of each value passed must have a suitable hashCode() function.
- */
-template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
-int hashCode6(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) {
-    int code = hashSeed();
-    code += hashCode(t1);
-    code *= hashMultiplier();
-    code += hashCode(t2);
-    code *= hashMultiplier();
-    code += hashCode(t3);
-    code *= hashMultiplier();
-    code += hashCode(t4);
-    code *= hashMultiplier();
-    code += hashCode(t5);
-    code *= hashMultiplier();
-    code += hashCode(t6);
-    return int(code & hashMask());
+    /* Hash the resulting integer to mask off any unneeded bits. */
+    return hashCode(result);
 }
 
 #include "private/init.h"   // ensure that Stanford C++ lib is initialized

--- a/StanfordCPPLib/graphics/gtypes.cpp
+++ b/StanfordCPPLib/graphics/gtypes.cpp
@@ -81,7 +81,7 @@ GDimension operator *(const GDimension& d, double scale) {
 }
 
 int hashCode(const GDimension& dim) {
-    return hashCode2(dim._width, dim._height);
+    return hashCode(dim._width, dim._height);
 }
 
 std::string toString(HorizontalAlignment alignment) {
@@ -211,7 +211,7 @@ GPoint operator *(const GPoint& p, double scale) {
 }
 
 int hashCode(const GPoint& pt) {
-    return hashCode2(pt._x, pt._y);
+    return hashCode(pt._x, pt._y);
 }
 
 /*
@@ -329,5 +329,5 @@ bool operator >=(const GRectangle& r1, const GRectangle& r2) {
 }
 
 int hashCode(const GRectangle& r) {
-    return hashCode4(r._x, r._y, r._width, r._height);
+    return hashCode(r._x, r._y, r._width, r._height);
 }

--- a/StanfordCPPLib/util/biginteger.cpp
+++ b/StanfordCPPLib/util/biginteger.cpp
@@ -719,7 +719,7 @@ std::string bigIntegerToString(const BigInteger& bi, int radix) {
 }
 
 int hashCode(const BigInteger& b) {
-    return hashCode2(b.getNumber(), b.getSign());
+    return hashCode(b.getNumber(), b.getSign());
 }
 
 BigInteger operator +(const BigInteger& b1, const BigInteger& b2) {

--- a/StanfordCPPLib/util/complex.cpp
+++ b/StanfordCPPLib/util/complex.cpp
@@ -39,7 +39,7 @@ std::string Complex::toString() const {
 }
 
 int hashCode(const Complex& c) {
-    return hashCode2(c.real(), c.imag());
+    return hashCode(c.real(), c.imag());
 }
 
 Complex operator *(const Complex& m, const Complex& n) {

--- a/StanfordCPPLib/util/intrange.cpp
+++ b/StanfordCPPLib/util/intrange.cpp
@@ -82,7 +82,7 @@ std::string IntRange::toString() const {
 }
 
 int hashCode(const IntRange& r) {
-    return hashCode2(r.min(), r.max());
+    return hashCode(r.min(), r.max());
 }
 
 IntRange range(int length) {
@@ -265,7 +265,7 @@ int IntRange2D::width() const {
 }
 
 int hashCode(const IntRange2D& r) {
-    return hashCode4(r.minX(), r.minY(), r.maxX(), r.maxY());
+    return hashCode(r.minX(), r.minY(), r.maxX(), r.maxY());
 }
 
 IntRange2D range2d(int width, int height, bool yMajor) {

--- a/StanfordCPPLib/util/note.cpp
+++ b/StanfordCPPLib/util/note.cpp
@@ -214,7 +214,7 @@ std::ostream& operator <<(std::ostream& out, const Note& note) {
 }
 
 int hashCode(const Note& note) {
-    return hashCode5(
+    return hashCode(
             note.getDuration(),
             note.getPitch(),
             note.getOctave(),

--- a/StanfordCPPLib/util/point.cpp
+++ b/StanfordCPPLib/util/point.cpp
@@ -55,5 +55,5 @@ std::ostream& operator <<(std::ostream& os, const Point& pt) {
 }
 
 int hashCode(const Point& pt) {
-    return hashCode2(pt.getX(), pt.getY());
+    return hashCode(pt.getX(), pt.getY());
 }


### PR DESCRIPTION
The previous version of hashcode.h exported a series of functions hashCode2, hashCode3, hashCode4, etc. that worked for multiple values. This branch replaces that with a variadic template function hashCode that extends hashCode to work for any number of arguments without the need for the explicit number of arguments to be specified.

This new hash code works similarly to the old ones, except that for simplicity reasons it computes the hash of the arguments as a sequence in reverse order.