### PR TITLE
Open iurlstream's file in binary mode for compatibility with Windows.

### DIFF
--- a/StanfordCPPLib/io/urlstream.cpp
+++ b/StanfordCPPLib/io/urlstream.cpp
@@ -5,6 +5,8 @@
  * Please see urlstream.h for information about how to use these classes.
  *
  * @author Marty Stepp
+ * @version 2018/08/11
+ * - open underlying file in binary mode for compatibility with Windows
  * @version 2018/06/20
  * - support for setting headers such as user agent
  * - https URL support
@@ -120,7 +122,7 @@ void iurlstream::open(const std::string& url) {
     }
 
     if (isHttpSuccess(m_lastError)) {
-        std::ifstream::open(m_tempFilePath.c_str());
+        std::ifstream::open(m_tempFilePath, std::ios::binary);
     } else {
         setstate(std::ios::failbit);
     }


### PR DESCRIPTION
The open() member function on iurlstream invokes the superclass .open() function to open the underlying file containing the bytes read from the server. In its current version, it doesn't specify the ios::binary flag, which causes the file to open in text mode. This causes problems in Windows when downloading binary data from a file (for example, a .png file).

I also removed the call to .c_str() from the ifstream::open call. Since C++11, the .c_str() bit hasn't been necessary. I'd like a sanity-check on this one, since there's some note about a previous version having a Mac-specific fix for .c_str() and I don't want to cause a regression!