### PR TITLE
Fix arrow operator for Set iterators.

### DIFF
--- a/StanfordCPPLib/collections/set.h
+++ b/StanfordCPPLib/collections/set.h
@@ -543,7 +543,7 @@ public:
         }
 
         ValueType* operator ->() {
-            return mapit;
+            return &**this;
         }
     };
 


### PR DESCRIPTION
The previous implementation of Set<T>::operator -> didn't compile because the return type didn't match the type being returned. I switched the implementation to use the "return &**this;" idiom, which implements operator -> in terms of operator *.