### PR TITLE
Fix segfaults due to reference counting errors in GTimer.

### DIFF
--- a/StanfordCPPLib/graphics/gevents.cpp
+++ b/StanfordCPPLib/graphics/gevents.cpp
@@ -57,7 +57,6 @@ GEvent::GEvent() {
     eventTime = 0.0;
     gwd = nullptr;
     source = nullptr;
-    gtd = nullptr;
     x = 0;
     y = 0;
     keyChar = 0;
@@ -573,7 +572,7 @@ GTimerEvent::GTimerEvent(EventType type, const GTimer& timer) {
 }
 
 GTimer GTimerEvent::getGTimer() const {
-    return GTimer(gtd);
+    return GTimer(gtd.lock());
 }
 
 std::string GTimerEvent::toString() const {
@@ -581,7 +580,7 @@ std::string GTimerEvent::toString() const {
         return "GTimerEvent(?)";
     }
     std::ostringstream out;
-    out << "GTimerEvent:TIMER_TICKED(id=" << gtd << ")";
+    out << "GTimerEvent:TIMER_TICKED(id=" << *gtd.lock() << ")";
     return out.str();
 }
 

--- a/StanfordCPPLib/graphics/gevents.h
+++ b/StanfordCPPLib/graphics/gevents.h
@@ -32,6 +32,7 @@
 #define _gevents_h
 
 #include <string>
+#include <cstdint>
 #include "gtable.h"
 #include "gtimer.h"
 #include "gwindow.h"
@@ -394,8 +395,17 @@ private:
     int column;
     std::string value;
 
-    /* Timer events */
-    GTimerData* gtd;
+    /* Timer events. We hold a weak pointer to the event rather than a shared_ptr
+     * so that if we're the last person to hold on to a GTimer, that timer gets
+     * deallocated.
+     *
+     * There's an auxiliary issue that this addresses: if, at program shutdown,
+     * there are GEvents sitting in the event queue that need to get cleaned up and
+     * they hold live references to internal IDs, there is a risk that, due to the
+     * nondeterministic order of static destruction, we'd try to touch the static
+     * table of GTimer IDs, which may have been destroyed before us.
+     */
+    std::weak_ptr<std::int64_t> gtd;
 
     /* Friend specifications */
     friend class GActionEvent;

--- a/StanfordCPPLib/graphics/gtimer.h
+++ b/StanfordCPPLib/graphics/gtimer.h
@@ -12,25 +12,12 @@
 #define _gtimer_h
 
 #include <string>
+#include <memory>
+#include <cstdint>
 
 namespace stanfordcpplib {
 class Platform;
 }
-
-/*
- * Friend type: GTimerData
- * -----------------------
- * This type maintains a reference count to determine when it is
- * possible to free the timer.
- */
-struct GTimerData {
-    GTimerData();
-    ~GTimerData();
-
-    static int instanceCount;
-    int id;
-    int refCount;
-};
 
 /*
  * Class: GTimer
@@ -54,13 +41,6 @@ public:
      * class.
      */
     GTimer(double milliseconds);
-
-    /*
-     * Destructor: ~GTimer
-     * -------------------
-     * Frees the resources associated with the timer.
-     */
-    virtual ~GTimer();
 
     /*
      * Method: getID
@@ -107,14 +87,20 @@ public:
      */
     bool operator !=(const GTimer& t2);
 
-    /* Private section */
-    GTimer(GTimerData* gtd);
-    GTimer(const GTimer& src);
-    GTimer& operator =(const GTimer& src);
+    /**
+     * Constructor: GTimer(shared_ptr<int64_t> id);
+     * ----------------------------------
+     * Creates a timer that shares state with another timer. This is used
+     * internally by the event system, and you should not use this
+     * constructor on your own.
+     */
+    GTimer(std::shared_ptr<std::int64_t> id);
 
 private:
     /* Instance variables */
-    GTimerData* gtd;
+    std::shared_ptr<std::int64_t> gtd;
+
+    static std::int64_t nextID;
 
     friend class stanfordcpplib::Platform;
     friend class GTimerEvent;

--- a/StanfordCPPLib/private/platform.h
+++ b/StanfordCPPLib/private/platform.h
@@ -316,7 +316,7 @@ public:
     void gtextlabel_constructor(GObject* gobj, const std::string& label);
 
     void gtimer_constructor(const GTimer& timer, double delay);
-    void gtimer_delete(const GTimer& timer);
+    void gtimer_delete(const std::string& timerID);
     void gtimer_pause(double milliseconds);
     void gtimer_start(const GTimer& timer);
     void gtimer_stop(const GTimer& timer);


### PR DESCRIPTION
It looks like the changes made to GTimer to avoid issues with GTimer destruction had some issues with referencing counting. I've swapped out the implementation of reference counting for std::shared_ptr and std::weak_ptr, which automatically handle all the reference counting for us.

Something I encountered while making these changes - which I think may come back to haunt us in the future - is that if you have any global GTimers that destruct when the program shuts down, they may try calling into the platform and referencing the (destructed) HashMap containing the mapping from GTimers to IDs. We might need to put in some extra logic to detect program shutdown and then intercept GTimer destruction logic to avoid these sorts of issues.

I'm asking for a code review here because I'm not sure that using std::shared_ptr or std::weak_ptr in our library implementations is something we're okay with. It dramatically simplifies the logic, which is why I've done this here, but I imagine that this might not be something we're okay with.