### PR TITLE
Prevent multiple copies of a GObject from being added to a GCompound.

### DIFF
--- a/StanfordCPPLib/graphics/gobjects.cpp
+++ b/StanfordCPPLib/graphics/gobjects.cpp
@@ -813,8 +813,12 @@ GCompound::GCompound() {
 }
 
 void GCompound::add(GObject* gobj) {
+    /* Don't add the same object multiple times. */
+    if (presences.contains(gobj)) return;
+
     stanfordcpplib::getPlatform()->gcompound_add(this, gobj);
     contents.add(gobj);
+    presences.add(gobj);
     gobj->parent = this;
 }
 
@@ -897,6 +901,7 @@ void GCompound::removeAll() {
 void GCompound::removeAt(int index) {
     GObject* gobj = contents[index];
     contents.remove(index);
+    presences.remove(gobj);
     stanfordcpplib::getPlatform()->gobject_remove(gobj);
     gobj->parent = nullptr;
 }

--- a/StanfordCPPLib/graphics/gobjects.h
+++ b/StanfordCPPLib/graphics/gobjects.h
@@ -28,6 +28,7 @@
 #include "gtypes.h"
 #include "gwindow.h"
 #include "vector.h"
+#include "hashset.h"
 
 // forward declaration of class
 class GCompound;
@@ -1054,7 +1055,8 @@ private:
     void removeAt(int index);
 
     /* Instance variables */
-    Vector<GObject*> contents;
+    Vector<GObject*>  contents;
+    HashSet<GObject*> presences;
 
     /* Friend declarations */
     friend class GObject;


### PR DESCRIPTION
If you try add()ing the same GObject to a GCompound multiple times, it will end up in the GCompound's list of objects multiple times. This means that calling remove() is not sufficient to remove it, which makes it easy to make mistakes of the form "add the object twice, then remove it once and delete it" leaving behind dangling pointers.

This fix makes GCompound::add() idempotent.