### PR TITLE
Stop GTimer when destructor is invoked.

### DIFF
--- a/StanfordCPPLib/graphics/gtimer.cpp
+++ b/StanfordCPPLib/graphics/gtimer.cpp
@@ -3,6 +3,8 @@
  * ----------------
  * This file implements the gtimer.h interface.
  * 
+ * @version 2019/01/23
+ * - added destructor
  * @version 2015/07/05
  * - removed static global Platform variable, replaced by getPlatform as needed
  * @version 2014/10/08

--- a/StanfordCPPLib/graphics/gtimer.cpp
+++ b/StanfordCPPLib/graphics/gtimer.cpp
@@ -30,6 +30,10 @@ GTimer::GTimer(double milliseconds)
     setDelay(milliseconds);
 }
 
+GTimer::~GTimer() {
+    stop();
+}
+
 double GTimer::getDelay() const {
     return _ms;
 }

--- a/StanfordCPPLib/graphics/gtimer.h
+++ b/StanfordCPPLib/graphics/gtimer.h
@@ -4,6 +4,8 @@
  * This file defines the <code>GTimer</code> class, which implements a
  * general interval timer.
  *
+ * @version 2019/01/23
+ * - added destructor
  * @version 2018/09/09
  * - updated to use new Qt GUI timer interface
  * - added doc comments for new documentation generation

--- a/StanfordCPPLib/graphics/gtimer.h
+++ b/StanfordCPPLib/graphics/gtimer.h
@@ -42,6 +42,11 @@ public:
     GTimer(double milliseconds);
 
     /**
+     * Destroys the timer, stopping it if it's currently running.
+     */
+    ~GTimer();
+
+    /**
      * Returns the delay in milliseconds between each tick of this timer.
      */
     double getDelay() const;


### PR DESCRIPTION
GTimer doesn't have a destructor, so when a GTimer is destroyed the timer continues firing. This adds a destructor that calls stop().