### PR TITLE
Add support for loading GImage / GCanvas directly from std::istream

### DIFF
--- a/StanfordCPPLib/graphics/gcanvas.cpp
+++ b/StanfordCPPLib/graphics/gcanvas.cpp
@@ -2,6 +2,9 @@
  * File: gcanvas.cpp
  * -----------------
  *
+ * @author Marty Stepp
+ * @version 2019/03/07
+ * - added support for loading canvas directly from istream (htiek)
  * @version 2019/02/06
  * - fixed mouse wheel listeners to work even if no actual scroll area exists
  * @version 2019/02/02
@@ -87,7 +90,7 @@ GCanvas::GCanvas(std::istream& source, QWidget* parent)
           _filename("std::istream data") {
     init(/* width */ -1, /* height */ -1, /* background */ 0xffffff, parent);
     if (!loadFromStream(source)) {
-        error("GCanvas::GCanvas: could not load image from input stream");
+        error("GCanvas::constructor: could not load image from input stream");
     }
 }
 
@@ -562,8 +565,9 @@ bool GCanvas::isAutoRepaint() const {
 
 void GCanvas::load(const std::string& filename) {
     std::ifstream input(filename);
-    if (!input) error("GCanvas::load: file \"" + filename + "\" not found.");
-
+    if (!input) {
+        error("GCanvas::load: file \"" + filename + "\" not found.");
+    }
     if (!loadFromStream(input)) {
         error("GCanvas::load: failed to load from " + filename);
     }

--- a/StanfordCPPLib/graphics/gcanvas.cpp
+++ b/StanfordCPPLib/graphics/gcanvas.cpp
@@ -82,6 +82,15 @@ GCanvas::GCanvas(const std::string& filename, QWidget* parent)
     load(filename);
 }
 
+GCanvas::GCanvas(std::istream& source, QWidget* parent)
+        : _backgroundImage(nullptr),
+          _filename("std::istream data") {
+    init(/* width */ -1, /* height */ -1, /* background */ 0xffffff, parent);
+    if (!loadFromStream(source)) {
+        error("GCanvas::GCanvas: could not load image from input stream");
+    }
+}
+
 GCanvas::GCanvas(double width, double height, int rgbBackground, QWidget* parent)
         : _backgroundImage(nullptr),
           _filename("") {
@@ -552,31 +561,38 @@ bool GCanvas::isAutoRepaint() const {
 }
 
 void GCanvas::load(const std::string& filename) {
-    // for efficiency, let's at least check whether the file exists
-    // and throw error immediately rather than contacting the back-end
-    if (!fileExists(filename)) {
-        error("GCanvas::load: file not found: " + filename);
+    std::ifstream input(filename);
+    if (!input) error("GCanvas::load: file \"" + filename + "\" not found.");
+
+    if (!loadFromStream(input)) {
+        error("GCanvas::load: failed to load from " + filename);
     }
 
+    _filename = filename;
+}
+
+bool GCanvas::loadFromStream(std::istream& input) {
+    // buffer bytes into a std::string
+    std::ostringstream byteStream;
+    byteStream << input.rdbuf();
+    std::string bytes = byteStream.str();
+
     bool hasError = false;
-    GThread::runOnQtGuiThread([this, filename, &hasError]() {
+    GThread::runOnQtGuiThread([&, this]() {
         ensureBackgroundImage();
         lockForWrite();
-        if (!_backgroundImage->load(QString::fromStdString(filename))) {
+        if (!_backgroundImage->loadFromData(reinterpret_cast<const uchar *>(bytes.data()), bytes.length())) {
             hasError = true;
             return;
         }
 
-        _filename = filename;
         GInteractor::setSize(_backgroundImage->width(), _backgroundImage->height());
         // setSize(_qimage->width(), _qimage->height());
         unlock();
         conditionalRepaint();
     });
 
-    if (hasError) {
-        error("GCanvas::load: failed to load from " + filename);
-    }
+    return !hasError;
 }
 
 void GCanvas::notifyOfResize(double width, double height) {

--- a/StanfordCPPLib/graphics/gcanvas.h
+++ b/StanfordCPPLib/graphics/gcanvas.h
@@ -3,6 +3,8 @@
  * ---------------
  *
  * @author Marty Stepp
+ * @version 2019/03/07
+ * - added support for loading canvas directly from istream (htiek)
  * @version 2018/09/10
  * - added doc comments for new documentation generation
  * @version 2018/09/04
@@ -143,7 +145,7 @@ public:
     /**
      * Creates a canvas that loads its background layer pixel data from
      * the given input stream
-     * @throw if the given stream cannot be read as a valid image file
+     * @throw ErrorException if the given stream cannot be read as a valid image file
      */
     GCanvas(std::istream& filename, QWidget* parent = nullptr);
 
@@ -454,6 +456,12 @@ public:
     virtual void load(const std::string& filename);
 
     /**
+     * Reads the canvas's pixel contents from the given input stream.
+     * @throw ErrorException if the given file does not exist or cannot be read
+     *        as a valid image file
+     */
+
+    /**
      * Removes the given graphical object from the foreground layer of the canvas,
      * if it was present.
      * @throw ErrorException if the graphical object is null
@@ -725,10 +733,18 @@ private:
 
     friend class _Internal_QCanvas;
 
-    bool loadFromStream(std::istream& input);
     void ensureBackgroundImage();
+
     void ensureBackgroundImageConstHack() const;
+
     void init(double width, double height, int rgbBackground, QWidget* parent);
+
+    /**
+     * Reads the canvas's pixel contents from the given stream.
+     * @return true if loaded successfully and false if the load failed
+     */
+    virtual bool loadFromStream(std::istream& input);
+
     void notifyOfResize(double width, double height);
 };
 

--- a/StanfordCPPLib/graphics/gcanvas.h
+++ b/StanfordCPPLib/graphics/gcanvas.h
@@ -141,6 +141,13 @@ public:
     GCanvas(const std::string& filename, QWidget* parent = nullptr);
 
     /**
+     * Creates a canvas that loads its background layer pixel data from
+     * the given input stream
+     * @throw if the given stream cannot be read as a valid image file
+     */
+    GCanvas(std::istream& filename, QWidget* parent = nullptr);
+
+    /**
      * Creates an empty canvas of the specified size and optional background color.
      * If no background color is passed, a default transparent background is used.
      * @throw ErrorException if the given width/height ranges are negative
@@ -718,6 +725,7 @@ private:
 
     friend class _Internal_QCanvas;
 
+    bool loadFromStream(std::istream& input);
     void ensureBackgroundImage();
     void ensureBackgroundImageConstHack() const;
     void init(double width, double height, int rgbBackground, QWidget* parent);

--- a/StanfordCPPLib/graphics/gobjects.cpp
+++ b/StanfordCPPLib/graphics/gobjects.cpp
@@ -4,6 +4,8 @@
  * This file implements the gobjects.h interface.
  *
  * @author Marty Stepp
+ * @version 2019/03/07
+ * - added support for loading a GImage directly from istream (htiek)
  * @version 2018/09/14
  * - added opacity support
  * - added GCanvas-to-GImage conversion support
@@ -988,11 +990,13 @@ GImage::GImage(const std::string& filename, double x, double y)
     if (!_filename.empty()) {
         // pull the bytes from the file and forward to the internal construction routine
         std::ifstream input(filename, std::ios::binary);
-        if (!input) error("GImage: file not found: \"" + filename + "\"");
+        if (!input) {
+            error("GImage::constructor: file not found: \"" + filename + "\"");
+        }
 
         // load from that source
         if (!loadFromStream(input)) {
-            error("GImage: unable to load image from: \"" + filename + "\"");
+            error("GImage::constructor: unable to load image from: \"" + filename + "\"");
         }
     }
 }
@@ -1002,7 +1006,7 @@ GImage::GImage(std::istream& source, double x, double y)
           _filename("std::istream source"),
           _qimage(nullptr) {
     if (!loadFromStream(source)) {
-        error("GImage: unable to load image from stream input");
+        error("GImage::constructor: unable to load image from stream input");
     }
 }
 

--- a/StanfordCPPLib/graphics/gobjects.h
+++ b/StanfordCPPLib/graphics/gobjects.h
@@ -965,6 +965,16 @@ public:
     GImage(const std::string& filename = "", double x = 0, double y = 0);
 
     /**
+     * Constructs a new image by loading the image from the specified input stream.
+     * By default, the upper left corner of the image appears at the origin,
+     * but you can pass coordinates to move it to the point
+     * (<code>x</code>, <code>y</code>).
+     * @throw ErrorException if the given file is not found or cannot be loaded
+     *        as a valid image file
+     */
+    GImage(std::istream& source, double x = 0, double y = 0);
+
+    /**
      * Creates a blank GImage of the given width and height.
      * Called by GCanvas when converting to an image.
      */
@@ -1021,6 +1031,8 @@ protected:
     QImage* getQImage() const;
 
 private:
+    bool loadFromStream(std::istream& input);
+
     std::string _filename;
     QImage* _qimage;
 

--- a/StanfordCPPLib/graphics/gobjects.h
+++ b/StanfordCPPLib/graphics/gobjects.h
@@ -6,6 +6,8 @@
  * <include src="pictures/ClassHierarchies/GObjectHierarchy-h.html">
  *
  * @author Marty Stepp
+ * @version 2019/03/07
+ * - added support for loading a GImage directly from istream (htiek)
  * @version 2018/09/14
  * - added opacity support
  * - added GCanvas-to-GImage conversion support
@@ -1031,6 +1033,10 @@ protected:
     QImage* getQImage() const;
 
 private:
+    /**
+     * Reads the image's pixel contents from the given stream.
+     * @return true if loaded successfully and false if the load failed
+     */
     bool loadFromStream(std::istream& input);
 
     std::string _filename;

--- a/StanfordCPPLib_QtCreatorProject/src/mainfunc-qt-2dgraphics.cpp
+++ b/StanfordCPPLib_QtCreatorProject/src/mainfunc-qt-2dgraphics.cpp
@@ -3,6 +3,7 @@
  */
 
 #include <iostream>
+#include <fstream>
 #include "gcolor.h"
 #include "gobjects.h"
 #include "ginteractors.h"
@@ -61,6 +62,8 @@ void testQwindowDrawing() {
     static double dx = 5;
     static double dy = 3;
     static GImage* image = nullptr;
+    static GImage* image2 = nullptr;
+    static GImage* image3 = nullptr;
 
     window = new GWindow(900, 500);
     // window->setCanvasSize(900, 500);
@@ -138,6 +141,7 @@ void testQwindowDrawing() {
 
     // foreground layer
     static GImage* gimage = nullptr;
+    static GImage* gimage2 = nullptr;
     if (TEST_FOREGROUND) {
         ball = new GOval(20, 20, 50, 50);
         ball->setFillColor("#aaff0033");
@@ -163,6 +167,12 @@ void testQwindowDrawing() {
         gimage->setOpacity(0.6);
         window->add(gimage);
 
+        std::ifstream input("triangle-icon.png", ios::binary);
+        if (!input) error("Oops - file is missing?");
+        gimage2 = new GImage(input, 300, 40);
+        gimage2->setOpacity(0.6);
+        window->add(gimage2);
+
         window->setColor("blue");
         GText* gtext3 = new GText("Third string", 240, 120);
         gtext3->setColor("blue");
@@ -174,6 +184,18 @@ void testQwindowDrawing() {
         canvas->fillRect(20, 20, 50, 30);
         image = canvas->toGImage();
         window->add(image, 300, 100);
+
+        GCanvas* canvas2 = new GCanvas("triangle-icon.png");
+        image2 = canvas2->toGImage();
+        window->add(image2, 500, 100);
+
+        std::ifstream input2("triangle-icon.png", ios::binary);
+        if (!input2) error("Oops: file is missing?");
+
+        GCanvas* canvas3 = new GCanvas(input2);
+        image3 = canvas3->toGImage();
+        image3->setLocation(600, 100);
+        window->add(image3);
     }
 
     if (TEST_LAYOUT_WIDGETS) {


### PR DESCRIPTION
Currently, GImage and GCanvas can load data from disk by passing a string into the constructor with the filename. This modification allows data to be pulled from any std::istream, including in-memory streams and on-disk streams.